### PR TITLE
Fix encryption col issue on fresh install

### DIFF
--- a/PasswordVault.Data/SQLiteDatabase.cs
+++ b/PasswordVault.Data/SQLiteDatabase.cs
@@ -501,7 +501,11 @@ namespace PasswordVault.Data
                         [FirstName] TEXT NOT NULL,
                         [LastName] TEXT NOT NULL,
                         [PhoneNumber] TEXT NOT NULL,
-                        [Email] TEXT NOT NULL
+                        [Email] TEXT NOT NULL,
+                        [PasswordEncryptionService] INTEGER,
+                        [PasswordBlockSize] INTEGER,
+                        [PasswordKeySize] INTEGER,
+                        [PasswordIterations] INTEGER
                     )");
 
                 dbConn.Execute(@"


### PR DESCRIPTION
The password encryption parameters columns were not being created in the
database table on a fresh install.

Hotfix_FixCreateUserTable